### PR TITLE
refactor: add mediasourcetype enum

### DIFF
--- a/src/MediaSourceType.ts
+++ b/src/MediaSourceType.ts
@@ -1,0 +1,7 @@
+export enum MediaSourceType {
+    MIC = 'mic',
+    WEBCAM = 'webcam',
+    SCREEN = 'screen',
+    SCREENAUDIO = 'screenaudio',
+    EXTRAVIDEO =  'extravideo'
+}


### PR DESCRIPTION
This can be used instead of strings, which is currently used here in edumeet-room-server:

https://github.com/edumeet/edumeet-room-server/blob/8beb65ff4a132031cbb8071bf576742762d3ed2f/src/common/authorization.ts#L177-L208