### PR TITLE
fix: export mediasourcetype

### DIFF
--- a/lib/MediaKind.d.ts
+++ b/lib/MediaKind.d.ts
@@ -1,0 +1,4 @@
+export declare const MediaKind: {
+    AUDIO: string;
+    VIDEO: string,
+};

--- a/lib/MediaKind.js
+++ b/lib/MediaKind.js
@@ -1,0 +1,7 @@
+"use strict";
+const MediaKind = Object.freeze({
+    AUDIO: 'audio',
+    VIDEO: 'video',
+})
+
+exports.MediaKind = MediaKind

--- a/lib/MediaSourceType.d.ts
+++ b/lib/MediaSourceType.d.ts
@@ -1,0 +1,7 @@
+export declare const MediaSourceType: {
+    MIC: string;
+    WEBCAM: string,
+    SCREEN: string,
+    SCREENAUDIO: string; 
+    EXTRAVIDEO: string
+};

--- a/lib/MediaSourceType.js
+++ b/lib/MediaSourceType.js
@@ -1,7 +1,10 @@
-export const MediaSourceType = Object.freeze({
+"use strict";
+const MediaSourceType = Object.freeze({
     MIC: 'mic',
     WEBCAM: 'webcam',
     SCREEN: 'screen',
     SCREENAUDIO: 'screenaudio',
     EXTRAVIDEO: 'extravideo'
-} as const)
+})
+
+exports.MediaSourceType = MediaSourceType

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,3 +8,4 @@ export { List } from './List';
 export { Logger } from './Logger';
 export { skipIfClosed } from './decorators';
 export { Next, Middleware, Pipeline } from './Middleware';
+export { MediaSourceType } from './MediaSourceType'

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -9,3 +9,4 @@ export { Logger } from './Logger';
 export { skipIfClosed } from './decorators';
 export { Next, Middleware, Pipeline } from './Middleware';
 export { MediaSourceType } from './MediaSourceType'
+import { MediaKind } from './MediaKind';

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -9,4 +9,4 @@ export { Logger } from './Logger';
 export { skipIfClosed } from './decorators';
 export { Next, Middleware, Pipeline } from './Middleware';
 export { MediaSourceType } from './MediaSourceType'
-import { MediaKind } from './MediaKind';
+export { MediaKind } from './MediaKind';

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,3 +19,5 @@ var decorators_1 = require("./decorators");
 Object.defineProperty(exports, "skipIfClosed", { enumerable: true, get: function () { return decorators_1.skipIfClosed; } });
 var Middleware_1 = require("./Middleware");
 Object.defineProperty(exports, "Pipeline", { enumerable: true, get: function () { return Middleware_1.Pipeline; } });
+var MediaSourceType_1 = require("./MediaSourceType");
+Object.defineProperty(exports, "MediaSourceType", { enumerable: true, get: function () { return MediaSourceType_1.MediaSourceType; } });

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,3 +21,5 @@ var Middleware_1 = require("./Middleware");
 Object.defineProperty(exports, "Pipeline", { enumerable: true, get: function () { return Middleware_1.Pipeline; } });
 var MediaSourceType_1 = require("./MediaSourceType");
 Object.defineProperty(exports, "MediaSourceType", { enumerable: true, get: function () { return MediaSourceType_1.MediaSourceType; } });
+var MediaKind_1 = require("./MediaKind");
+Object.defineProperty(exports, "MediaKind", { enumerable: true, get: function () { return MediaKind_1.MediaKind; } });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "edumeet-common",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"description": "Common code for edumeet",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "edumeet-common",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Common code for edumeet",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",

--- a/src/MediaKind.ts
+++ b/src/MediaKind.ts
@@ -1,0 +1,4 @@
+export const MediaKind = Object.freeze({
+    AUDIO: 'audio',
+    VIDEO: 'video',
+} as const)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,5 @@ export { List } from './List';
 export { Logger } from './Logger';
 export { skipIfClosed } from './decorators';
 export { Next, Middleware, Pipeline } from './Middleware';
+export { MediaSourceType } from './MediaSourceType'
+export { MediaKind } from './MediaKind'


### PR DESCRIPTION
This PR will export `MediaSourceType` properly, which I missed in previous PR.
I also opted to go with `const Object.freeze()` instead of `enum`.

I do not have a lot of experience exporting modules intended for library use.
I've tried that it works but please have a look at my export. 